### PR TITLE
Update attachments_controller.rb

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -56,7 +56,7 @@ class AttachmentsController < ApplicationController
 
   def s3_resource
     @s3_resource ||= begin
-      creds = Aws::Credentials.new("AKIA4NGXA5VZ3EAA26XL", "+Oxg1vVP3TqFG9P+PvC8DNG6JtuqKRsioHAU9Iyp")
+      creds = Aws::Credentials.new("AKIA4NGXA5VZ3EAA26XL", "+Oxg1vVP3TqFG9P+PvC8DNG6JtuqKRsioHAU9Iyp") ## hide these in a .env file (add to .gitignore) and access with dotenv
       Aws::S3::Resource.new(region: 'us-west-1', credentials: creds)
     end
   end


### PR DESCRIPTION
FYI -- I saw your post on HN. Anyone can access your s3 instance since you've exposed the private/public keys. Instead, use something like dotenv to hide these variables so that non-privileged actors can't access your db. For example, I was able to see that your 2 buckets are "backgroundsland" and "beatoftheday" but simply read their names...not everyone will do the same.
<img width="564" alt="Screen Shot 2021-05-16 at 12 50 32 PM" src="https://user-images.githubusercontent.com/13358940/118410778-d0b68f80-b656-11eb-8c8e-ee7aed185004.png">
